### PR TITLE
Quest Reminders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /node_modules
 /db.sqlite
 /.env
+/.vscode

--- a/bun.d.ts
+++ b/bun.d.ts
@@ -5,5 +5,6 @@ declare module "bun" {
     DISCORD_APPLICATION_ID: string;
     DISCORD_CHANNEL_ID: string;
     SCHEDULE: string;
+    QUEST_SCHEDULE: string;
   }
 }

--- a/src/db.ts
+++ b/src/db.ts
@@ -9,6 +9,7 @@ export type Quest = {
   id: string;
   name: string;
   description: string;
+  position: number;
 };
 
 export const db = new Database(Bun.env.DATABASE_URL);
@@ -24,7 +25,8 @@ db.exec(`
     CREATE TABLE IF NOT EXISTS quests (
       id TEXT PRIMARY KEY,
       name TEXT,
-      description TEXT
+      description TEXT,
+      position INTEGER NOT NULL UNIQUE
     );
   `)
 
@@ -42,9 +44,9 @@ export const replaceQuests = (quests: Quest[]): void => {
   db.transaction(() => {
     db.prepare("DELETE FROM quests").run();
     const stmt = db.prepare(
-      "INSERT INTO quests (id, name, description) VALUES (?, ?, ?)"
+      "INSERT INTO quests (id, name, description, position) VALUES (?, ?, ?, ?)"
     );
-    quests.forEach((quest) => stmt.run(quest.id, quest.name, quest.description));
+    quests.forEach((quest, index) => stmt.run(quest.id, quest.name, quest.description, index));
   })();
 };
 
@@ -59,10 +61,10 @@ export const getRecapper = () =>
 export const getQuests = () =>
   db
     .prepare<
-      Quest[],
+      Quest,
       []
-    >("SELECT * FROM quests ORDER BY name ASC LIMIT 10")
-    .get();
+    >("SELECT * FROM quests ORDER BY position ASC LIMIT 10")
+    .all();
 
 export const cycleRecapper = (): void => {
   db.prepare(

--- a/src/discord/commands/ingest.ts
+++ b/src/discord/commands/ingest.ts
@@ -1,9 +1,9 @@
 import { SlashCommandBuilder, type CommandInteraction } from "discord.js";
-import { replaceQuests, db, Quest } from "../../db";
+import { replaceQuests, db, Quest, getQuests } from "../../db";
 
-export const skip = {
+export const quests = {
   data: new SlashCommandBuilder()
-    .setName("ingest")
+    .setName("quests")
     .setDescription("Ingest a JSON document containing a list of quests")
     .addStringOption(
         option => option
@@ -14,9 +14,10 @@ export const skip = {
   handler: async (interaction: CommandInteraction) => {
     db.transaction(async () => {
 
-      let data = interaction.options.get('json')?.value;
+      let data = interaction.options.get('quests')?.value;
       if (!data || typeof(data) !== "string")
       {
+        console.log(`${data}`);
         await interaction.reply("You must provide some quests.");
         return;
       }

--- a/src/discord/commands/ingestQuest.ts
+++ b/src/discord/commands/ingestQuest.ts
@@ -1,0 +1,36 @@
+import { SlashCommandBuilder, type CommandInteraction } from "discord.js";
+import { replaceQuests, db, Quest } from "../../db";
+
+export const skip = {
+  data: new SlashCommandBuilder()
+    .setName("ingest")
+    .setDescription("Ingest a JSON document containing a list of quests")
+    .addStringOption(
+        option => option
+            .setName('quests')
+            .setDescription("A list of quests")
+            .setRequired(true)
+    ),
+  handler: async (interaction: CommandInteraction) => {
+    db.transaction(async () => {
+
+      let data = interaction.options.get('json')?.value;
+      if (!data || typeof(data) !== "string")
+      {
+        await interaction.reply("You must provide some quests.");
+        return;
+      }
+
+      const quests = <Quest[]> JSON.parse(data as string);
+      if (quests == null)
+      {
+        await interaction.reply("Unable to read provided quests.");
+        return;
+      }
+      
+      replaceQuests(quests);
+      
+      await interaction.reply("Refreshed quests with the most current list.");
+    })();
+  },
+};

--- a/src/discord/discord.ts
+++ b/src/discord/discord.ts
@@ -8,8 +8,9 @@ import {
 } from "discord.js";
 import { skip } from "./commands/skip";
 import { replace } from "./commands/replace";
+import { quests } from "./commands/ingest"
 
-const commands = { skip, replace };
+const commands = { skip, replace, quests };
 
 export const registerCommands = async () => {
   const rest = new REST().setToken(Bun.env.DISCORD_TOKEN);

--- a/src/schedule.ts
+++ b/src/schedule.ts
@@ -1,6 +1,6 @@
 import { CronJob } from "cron";
 import type { Client, TextChannel } from "discord.js";
-import { cycleRecapper, getRecapper } from "./db";
+import { cycleRecapper, getRecapper, Quest, getQuests } from "./db";
 
 export const startSchedule = (bot: Client) => {
   const rotateRecapperSchedule = new CronJob(Bun.env.SCHEDULE, async () => {
@@ -20,5 +20,19 @@ export const startSchedule = (bot: Client) => {
       `Session starts in 1 hour (unless rescheduled). Recapper is <@${recappingUser.id}>. Next recapper is <@${nextRecappingUser.id}>.`,
     );
   });
+
+  const announceQuests = new CronJob(Bun.env.QUEST_SCHEDULE, async () => {
+    const quests = getQuests();
+    let questText : string = "The next session is scheduled for <some_time>. Here are some highlights from last session: Here are your pending quests:";
+    if (quests)
+      {
+        quests.forEach(quest => {
+          questText += "* " + quest.name + quest.description;
+        });
+      }
+
+  });
+
   rotateRecapperSchedule.start();
+  announceQuests.start();
 };

--- a/src/schedule.ts
+++ b/src/schedule.ts
@@ -23,14 +23,19 @@ export const startSchedule = (bot: Client) => {
 
   const announceQuests = new CronJob(Bun.env.QUEST_SCHEDULE, async () => {
     const quests = getQuests();
-    let questText : string = "The next session is scheduled for <some_time>. Here are some highlights from last session: Here are your pending quests:";
-    if (quests)
+    const channel = await bot.channels.fetch(Bun.env.DISCORD_CHANNEL_ID);
+    const textChannel = channel as TextChannel;
+    let questText : string = "The next session is coming up! Here are your pending quests:";
+    if (quests && quests.length > 0)
       {
-        quests.forEach(quest => {
-          questText += "* " + quest.name + quest.description;
+        quests.forEach((quest, index) => {
+          questText += `\r\n${index}. **${quest.name}**: ${quest.description}`;
         });
+        textChannel.send(
+          questText,
+        );
       }
-
+      
   });
 
   rotateRecapperSchedule.start();


### PR DESCRIPTION
**Summary**

This change adds a new slash command, '/quests', which allows a user to submit a JSON dump of active requests from a Roll20 server using the 'Questor' mod. On a separate schedule from the recap, users in the main channel will be reminded of the top ten pending quests, ordered by priority (main / side).

**Change List**

- Added a new database table, quests
- Added a new database model, 'Quest':
  - Includes an ID, name, description, and position
- Added a new environment variable, QUEST_SCHEDULE
- Added a new slash command, /quests, to ingest a list of quests
- Added new CronJob, announceQuests, to schedule the announcement of quests ahead of a game